### PR TITLE
Add minimal tests for CSV parsing and GUI toggling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_qt_offscreen():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/data/sample_shots.csv
+++ b/tests/data/sample_shots.csv
@@ -1,0 +1,4 @@
+shot_id,reparto,frame_path,start_frame,end_frame
+s1,animazione,path/shot1/frame####.png,1,3
+audio,,path/audio.wav,,
+s2,animazione,path/shot2/frame####.png,1,2

--- a/tests/test_gui_toggle_mode.py
+++ b/tests/test_gui_toggle_mode.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+import pytest
+
+# Ensure project root is on sys.path
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+pytest.importorskip("PyQt5")
+
+# Stub pygame if missing
+if 'pygame' not in sys.modules:
+    pygame_stub = types.ModuleType('pygame')
+    pygame_stub.mixer = types.SimpleNamespace(get_init=lambda: False, music=types.SimpleNamespace())
+    sys.modules['pygame'] = pygame_stub
+
+from player_core import parse_shot_list
+from gui import PlayerGUI
+
+
+def test_gui_toggle_mode(qtbot):
+    csv_path = os.path.join(os.path.dirname(__file__), 'data', 'sample_shots.csv')
+    shots, _ = parse_shot_list(csv_path)
+
+    gui = PlayerGUI()
+    qtbot.addWidget(gui)
+
+    gui.loaded_shots = shots
+    gui.resume_frame_index = 4  # global frame within second shot
+
+    gui.toggle_episode_mode()  # Episode -> Scene
+    assert gui.mode_episode is False
+    assert gui.current_shot == shots[1]
+    assert gui.resume_frame_index == 1
+
+    gui.toggle_episode_mode()  # Scene -> Episode
+    assert gui.mode_episode is True
+    assert gui.resume_frame_index == 4

--- a/tests/test_parse_shot_list.py
+++ b/tests/test_parse_shot_list.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import types
+
+# Ensure project root is on sys.path
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# Provide minimal stubs so player_core can be imported without optional deps
+sys.modules.setdefault('cv2', types.ModuleType('cv2'))
+pygame_stub = types.ModuleType('pygame')
+pygame_stub.mixer = types.SimpleNamespace(get_init=lambda: False, music=types.SimpleNamespace())
+sys.modules.setdefault('pygame', pygame_stub)
+
+qtgui = types.ModuleType('PyQt5.QtGui')
+qtgui.QPixmap = object
+qtgui.QImage = object
+qtcore = types.ModuleType('PyQt5.QtCore')
+qtcore.Qt = types.SimpleNamespace(KeepAspectRatio=0)
+sys.modules.setdefault('PyQt5', types.ModuleType('PyQt5'))
+sys.modules.setdefault('PyQt5.QtGui', qtgui)
+sys.modules.setdefault('PyQt5.QtCore', qtcore)
+
+from player_core import parse_shot_list
+
+
+def test_parse_shot_list():
+    csv_path = os.path.join(os.path.dirname(__file__), 'data', 'sample_shots.csv')
+    shots, audio = parse_shot_list(csv_path)
+    assert audio == 'path/audio.wav'
+    assert len(shots) == 2
+    assert shots[0].shot_id == 's1'
+    assert shots[0].absolute_start == 0
+    assert shots[1].shot_id == 's2'
+    # shot1 length is 3 frames -> shot2 starts at 3
+    assert shots[1].absolute_start == 3


### PR DESCRIPTION
## Summary
- create pytest configuration and sample CSV data
- add fixture to force offscreen Qt usage
- test CSV shot parsing logic
- test GUI episode/scena toggle logic (skipped if PyQt5 missing)

## Testing
- `pytest -q`