### PR TITLE
Fix scene toggle for duplicate department shots

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -480,7 +480,11 @@ class PlayerGUI(QMainWindow):
         # se stiamo passando a SCENA deduci lo shot corrente dal frame globale
         if not self.mode_episode:
             for sh in self.loaded_shots:
-                if sh.absolute_start <= self.resume_frame_index <= sh.absolute_start + (sh.end_frame - sh.start_frame):
+                if sh.reparto != self.current_reparto:
+                    continue
+                if sh.absolute_start <= self.resume_frame_index <= (
+                    sh.absolute_start + (sh.end_frame - sh.start_frame)
+                ):
                     self.current_shot = sh
                     break
         # [PATCH] sincronizza indice frame quando si cambia modalità

--- a/tests/test_gui_toggle_mode.py
+++ b/tests/test_gui_toggle_mode.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import queue
 import pytest
 
 # Ensure project root is on sys.path
@@ -16,7 +17,7 @@ if 'pygame' not in sys.modules:
     pygame_stub.mixer = types.SimpleNamespace(get_init=lambda: False, music=types.SimpleNamespace())
     sys.modules['pygame'] = pygame_stub
 
-from player_core import parse_shot_list
+from player_core import parse_shot_list, Shot
 from gui import PlayerGUI
 
 
@@ -38,3 +39,34 @@ def test_gui_toggle_mode(qtbot):
     gui.toggle_episode_mode()  # Scene -> Episode
     assert gui.mode_episode is True
     assert gui.resume_frame_index == 4
+
+
+def test_gui_toggle_mode_duplicate_departments(qtbot):
+    shots = [
+        Shot("s1", "animazione", "anim/shot1/frame####.png", 1, 3, absolute_start=0),
+        Shot("s1", "render", "render/shot1/frame####.png", 1, 3, absolute_start=0),
+        Shot("s2", "animazione", "anim/shot2/frame####.png", 1, 2, absolute_start=3),
+        Shot("s2", "render", "render/shot2/frame####.png", 1, 2, absolute_start=3),
+    ]
+
+    gui = PlayerGUI()
+    qtbot.addWidget(gui)
+
+    gui.loaded_shots = shots
+    gui.current_reparto = "render"
+    gui.resume_frame_index = 4  # global frame within second shot
+    gui.command_q = queue.Queue()
+
+    gui.toggle_episode_mode()  # Episode -> Scene
+    assert gui.mode_episode is False
+    assert gui.current_shot == shots[3]
+    assert gui.resume_frame_index == 1
+    assert gui.command_q.get_nowait() == ("trim", (3, 4))
+    assert gui.command_q.get_nowait() == ("seek", 4)
+    assert gui.command_q.empty()
+
+    gui.toggle_episode_mode()  # Scene -> Episode
+    assert gui.mode_episode is True
+    assert gui.resume_frame_index == 4
+    assert gui.command_q.get_nowait() == ("trim_off", None)
+    assert gui.command_q.empty()


### PR DESCRIPTION
## Summary
- ensure current shot detection respects selected reparto
- check department when issuing trim/seek in toggle_episode_mode
- add regression test for duplicate shots across departments

## Testing
- `pytest -q`
